### PR TITLE
Remove the Flush method from ResponseWriter

### DIFF
--- a/response.go
+++ b/response.go
@@ -72,11 +72,6 @@ func (w *ResponseWriter) HeaderWritten() bool {
 	return w.headerWritten
 }
 
-// Flush wraps response writer's Flush function.
-func (w *ResponseWriter) Flush() {
-	w.ResponseWriter.(http.Flusher).Flush()
-}
-
 // Hijack wraps response writer's Hijack function.
 func (w *ResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return w.ResponseWriter.(http.Hijacker).Hijack()


### PR DESCRIPTION
The embedded http.ResponseWriter implements http.Flusher interface so it
is really not necessary to typecast and re expose the method from the
embedded struct while it is already available.

In short, by embedding http.ResponseWriter, the ResponseWriter struct
satisfies the http.Flusher interface.